### PR TITLE
Create riverwaterfront access

### DIFF
--- a/riverwaterfront access
+++ b/riverwaterfront access
@@ -1,0 +1,10 @@
+Map with:
+-- Oregon certified clean public marinas  (filtered to City of Portland)
+-- PFD stations
+-- Boating access sites
+-- Services at boating access sites (restrooms, water) 
+-- NW Oregon Swimming Holes
+
+Filtered by county where possible: Multomah, Clackamas, Columbia, Washington
+
+https://www.arcgis.com/apps/mapviewer/index.html?webmap=b43a84ac8fbb4ecd9ce13942b3f12537


### PR DESCRIPTION
Can't download datasets so map must be integrated: 

Map with:
-- Oregon certified clean public marinas  (filtered to City of Portland) -- PFD stations
-- Boating access sites
-- Services at boating access sites (restrooms, water)  -- NW Oregon Swimming Holes

Filtered by county where possible: Multomah, Clackamas, Columbia, Washington

https://www.arcgis.com/apps/mapviewer/index.html?webmap=b43a84ac8fbb4ecd9ce13942b3f12537